### PR TITLE
Relocate location info

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -6,7 +6,7 @@
         <time datetime="{{ include.post.date | date_to_xmlschema }}" class="post-date">{{ include.post.date | date: "%A, %B %-d, %Y" }}</time>
     </header>
     <div class="post-body">
-        {{ include.content }}
+        <a href="https://www.google.com/maps/search/{{ include.post.location }}" target="_blank" class="post-body-location">{{ include.post.location }}</a><span class="post-body-location-divider">—</span>{{ include.content }}
     </div>
     <footer class="post-footer">
         <a href="https://www.google.com/maps/search/{{ include.post.location }}" target="_blank" class="post-footer-location">{{ include.post.location }}</a>

--- a/_sass/modules/post/_rules.scss
+++ b/_sass/modules/post/_rules.scss
@@ -83,7 +83,15 @@
         letter-spacing: 0.04em;
         text-transform: uppercase;
         margin-right: 5px;
-        line-height: 1.2;
+
+        // A line-height of 1.2 makes our font (Bodoni) align well horizontally with
+        // the paragraph font (Caslon) however we need to ensure that the location
+        // text displays nicely if wrapped across multiple lines. To solve this,
+        // we increase the line-height while offsetting it's position upwards slightly.
+        // This will keep the alignment between Bodoni & Caslon AND wrap nicely.
+        line-height: 1.4;
+        position: relative;
+        top: -2px;
     }
 
     .post-body-location-divider {

--- a/_sass/modules/post/_rules.scss
+++ b/_sass/modules/post/_rules.scss
@@ -73,6 +73,24 @@
         }
     }
 
+    .post-body-location,
+    .post-body-location-divider {
+        float: left;
+    }
+
+    .post-body-location {
+        font-family: "ltc-bodoni-175", serif;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        margin-right: 5px;
+        line-height: 1.2;
+    }
+
+    .post-body-location-divider {
+        margin-right: 6px;
+        line-height: 1.4;
+    }
+
     .post-image {
         margin-bottom: 25px;
         margin-top: 30px;

--- a/_sass/modules/post/_rules.scss
+++ b/_sass/modules/post/_rules.scss
@@ -177,14 +177,9 @@
     }
 
     .post-footer {
-        padding: 10px 0 5px;
-        text-align: center;
-
-        // Child is floated, so use a clearfix on the parent
-        @include clearfix;
-
-        @include min-breakpoint($image-splitting-breakpoint) {
-            padding: 0;
+        @include min-breakpoint($desktop-breakpoint) {
+            // Child is floated, so use a clearfix on the parent
+            @include clearfix;
         }
     }
 

--- a/_sass/modules/post/_rules.scss
+++ b/_sass/modules/post/_rules.scss
@@ -171,32 +171,30 @@
     }
 
     .post-footer-location {
-        @include retina-background-image($img-location, $img-location-2x, $img-location-3x);
-        background-repeat: no-repeat;
-        background-position: left center;
-        background-color: transparent;
-        background-size: 44px;
-        min-height: 21px;
-        padding-left: 55px;
+        display: none;
 
-        // The font used (Adobe Caslon Pro) has a peculiar line-height. This
-        // adjusts the position of the text in relation to the icon without
-        // adjusting the line-height property itself
-        margin-top: -9px;
-        padding-top: 9px;
-
-        // Force legal text colour [as it is a link]
-        color: $legal-text-color;
-
-        // However let the normal hover colour apply
-        &:hover { color: $hover-color; }
-
-        @include min-breakpoint($image-splitting-breakpoint) {
-            // Switch icon from left to right side
+        @include min-breakpoint($desktop-breakpoint) {
+            @include retina-background-image($img-location, $img-location-2x, $img-location-3x);
+            display: block;
+            background-repeat: no-repeat;
             background-position: right center;
+            background-color: transparent;
+            background-size: 44px;
+            min-height: 21px;
             padding-right: 55px;
-            padding-left: 0;
             float: right;
+
+            // The font used (Adobe Caslon Pro) has a peculiar line-height. This
+            // adjusts the position of the text in relation to the icon without
+            // adjusting the line-height property itself
+            margin-top: -9px;
+            padding-top: 9px;
+
+            // Force legal text colour [as it is a link]
+            color: $legal-text-color;
+
+            // However let the normal hover colour apply
+            &:hover { color: $hover-color; }
         }
     }
 }


### PR DESCRIPTION
Display location at start of post, similar to how this is done in newspaper articles, eg:

![screen shot 2015-11-30 at 9 36 42 am](https://cloud.githubusercontent.com/assets/185649/11463325/fda7050a-9745-11e5-8e82-67e5e0eee901.png)
![screen shot 2015-11-30 at 9 35 48 am](https://cloud.githubusercontent.com/assets/185649/11463328/016bdf3a-9746-11e5-8b63-adc0a058fa36.png)
_Examples taken from the NYT & WSJ_

At larger resolutions, the original location meta-data should display at the bottom of the post as usual. The duplication may be beneficial on longer posts.
