### PR TITLE
add rubygems as source to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+source 'https://rubygems.org'
+
 gem 'jekyll'
 gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     colorator (0.1)
     ffi (1.9.8)
@@ -35,3 +36,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-paginate
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
Without giving a source, bundle doesn't know where to pull the gems from.

Thanks for the nice template!